### PR TITLE
Fix crashes, threading issues, and unsafe unwraps

### DIFF
--- a/SwiftyTorrent/Models/EZTVDataProvider.swift
+++ b/SwiftyTorrent/Models/EZTVDataProvider.swift
@@ -57,19 +57,22 @@ final class EZTVDataProvider: EZTVDataProviderProtocol {
     static let endpoint = "https://eztv.re/api/"
 
     private let urlSession: URLSession = URLSession.shared
-    private let endpointURL = URL(string: endpoint)!
+    private let endpointURL = URL(string: endpoint)
     
     func fetchTorrents(imdbId: String, page: Int) -> AnyPublisher<[SearchDataItem], Error> {
         fetchTorrents(imdbId: imdbId, limit: 20, page: page)
     }
     
     private func fetchTorrents(imdbId: String, limit: Int, page: Int) -> AnyPublisher<[SearchDataItem], Error> {
-        let requestURL = URL(string: endpointURL.absoluteString +
-                             "get-torrents?" +
-                             "limit=\(limit)&" +
-                             "page=\(page)&" +
-                             "imdb_id=\(imdbId)"
-        )!
+        guard let endpointURL = endpointURL,
+              let requestURL = URL(string: endpointURL.absoluteString +
+                                   "get-torrents?" +
+                                   "limit=\(limit)&" +
+                                   "page=\(page)&" +
+                                   "imdb_id=\(imdbId)") else {
+            return Fail(error: URLError(.badURL)).eraseToAnyPublisher()
+        }
+
         return urlSession
             .dataTaskPublisher(for: requestURL)
             .tryMap({ data, response -> Data in

--- a/SwiftyTorrent/Models/File.swift
+++ b/SwiftyTorrent/Models/File.swift
@@ -113,12 +113,13 @@ public class Directory: FileProtocol, CustomStringConvertible {
                     let file = File(name: component, path: path, size: fileEntry.size)
                     lastDir.files.append(file)
                 } else {
-                    var dir: Directory! = lastDir.files.first(where: { $0.name == component }) as? Directory
+                    var dir = lastDir.files.first(where: { $0.name == component }) as? Directory
                     if dir == nil {
-                        dir = Directory(name: component, path: path)
-                        lastDir.files.append(dir)
+                        let newDir = Directory(name: component, path: path)
+                        lastDir.files.append(newDir)
+                        dir = newDir
                     }
-                    lastDir = dir
+                    lastDir = dir!
                 }
             }
         }

--- a/SwiftyTorrent/Models/IMDBDataProvider.swift
+++ b/SwiftyTorrent/Models/IMDBDataProvider.swift
@@ -20,7 +20,7 @@ protocol IMDBDataProviderProtocol {
 final class IMDBDataProvider: IMDBDataProviderProtocol {
 
     private let urlSession: URLSession = URLSession.shared
-    private let endpointURL = URL(string: "https://sg.media-imdb.com/")!
+    private let endpointURL = URL(string: "https://sg.media-imdb.com/")
     
     private var cache = [String: String]()
     
@@ -33,6 +33,10 @@ final class IMDBDataProvider: IMDBDataProviderProtocol {
                 .eraseToAnyPublisher()
         }
         // Constructs path like: `suggests/s/simpsons.json`
+        guard let endpointURL = endpointURL else {
+            return Fail(error: URLError(.badURL)).eraseToAnyPublisher()
+        }
+
         let requestURL = endpointURL.appendingPathComponent("suggests/\(query.prefix(1))/\(query).json")
         return urlSession
             .dataTaskPublisher(for: requestURL)
@@ -45,13 +49,18 @@ final class IMDBDataProvider: IMDBDataProviderProtocol {
             }
             .tryMap { (data) -> Data in
                 // Strip json-p padding `imdb$search_query()`
-                var value = String(bytes: data, encoding: .utf8)!
+                guard var value = String(bytes: data, encoding: .utf8) else {
+                    throw URLError(.cannotDecodeContentData)
+                }
                 if let idx = value.firstIndex(of: "(") {
                     value.removeSubrange(value.startIndex..<idx)
                     value = String(value.dropFirst())
                     value = String(value.dropLast())
                 }
-                return value.data(using: .utf8)!
+                guard let data = value.data(using: .utf8) else {
+                    throw URLError(.cannotDecodeContentData)
+                }
+                return data
             }
             .decode(type: Response.self, decoder: JSONDecoder())
             .tryMap { imdbResponse -> String in

--- a/SwiftyTorrent/Models/Torrent+Files.swift
+++ b/SwiftyTorrent/Models/Torrent+Files.swift
@@ -18,18 +18,27 @@ extension Torrent {
     private static var dirsCache = [Data: Directory]()
     
     private var fileEntries: [FileEntry] {
-        if Torrent.filesCache[infoHash] == nil {
-            Torrent.filesCache[infoHash] = torrentManager.filesForTorrent(withHash: infoHash)
+        if let files = Torrent.filesCache[infoHash] {
+            return files
         }
-        return Torrent.filesCache[infoHash]!
+
+        let files = torrentManager.filesForTorrent(withHash: infoHash) ?? []
+        if !files.isEmpty {
+            Torrent.filesCache[infoHash] = files
+        }
+        return files
     }
 
     var directory: Directory {
-        if Torrent.dirsCache[infoHash] == nil {
-            let dir = Directory.directory(from: fileEntries)
-           Torrent.dirsCache[infoHash] = dir
+        if let dir = Torrent.dirsCache[infoHash] {
+            return dir
         }
-        return Torrent.dirsCache[infoHash]!
+
+        let dir = Directory.directory(from: fileEntries)
+        if !fileEntries.isEmpty {
+            Torrent.dirsCache[infoHash] = dir
+        }
+        return dir
     }
 
 }

--- a/SwiftyTorrent/UI/TorrentsView.swift
+++ b/SwiftyTorrent/UI/TorrentsView.swift
@@ -53,7 +53,11 @@ struct TorrentsView: View {
             .navigationBarTitle("Torrents")
         }
         .alert(isPresented: model.isPresentingAlert) { () -> Alert in
-            Alert(error: model.activeError!)
+            if let error = model.activeError {
+                return Alert(error: error)
+            } else {
+                return Alert(title: Text("Unknown Error"))
+            }
         }
     }
 

--- a/SwiftyTorrent/UI/TorrentsViewModel.swift
+++ b/SwiftyTorrent/UI/TorrentsViewModel.swift
@@ -43,6 +43,12 @@ final class TorrentsViewModel: NSObject, ObservableObject, TorrentManagerDelegat
     }
     
     func reloadData() {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async {
+                self.reloadData()
+            }
+            return
+        }
         torrentsWillChangeSubject.send()
         torrents = torrentManager.torrents()
             .sorted(by: { $0.name < $1.name })


### PR DESCRIPTION
- Fix force unwrap crash in `Torrent+Files.swift` when caching files/dirs.
- Fix threading violation in `TorrentsViewModel.swift` by dispatching UI updates to main thread.
- Fix force unwrap crash in `TorrentsView.swift` when presenting alerts.
- Refactor `File.swift` to remove implicitly unwrapped optional usage.
- Refactor `EZTVDataProvider` and `IMDBDataProvider` to safely handle URL creation and string decoding, removing force unwraps.